### PR TITLE
Fix regex that breaks multi-condition breakpoints.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yy",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "authors": [
     "benib <bbuess@astina.ch>",
     "mzgajner <mzgajner@astina.ch>"

--- a/examples/breakpoint/json.js
+++ b/examples/breakpoint/json.js
@@ -3,7 +3,7 @@ var style;
 if ( window.getComputedStyle ) {
     style = window.getComputedStyle(document.body, "::before")
                   .getPropertyValue("content")
-                  .replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
+                  .replace(/^['"]+|\\|(;\s?})+|['"]$/g, '');
 }
 
 style = JSON.parse(style);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yy",
   "title": "yy",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "a collection of sass utilities",
   "homepage": "https://github.com/astina/yy",
   "main": "Gruntfile.js",

--- a/tests/expected/json.css
+++ b/tests/expected/json.css
@@ -1,4 +1,4 @@
 body::before {
-  content: '{\\"small\\":\\"(min-width:  400px) and (max-width:  767px)\\", \\"small-up\\":\\"(min-width:400px)\\", \\"medium-up\\":\\"screen and (min-width:768px)\\", \\"large-up\\":\\"(min-width:  992px)\\"}';
+  content: '{\\"small\\":\\"(min-width:  400px) and (max-width:  767px)\\", \\"small-up\\":\\"(min-width:400px)\\", \\"medium\\":\\"screen and (min-width:768px) and (max-width:991px)\\", \\"medium-up\\":\\"screen and (min-width:768px)\\", \\"large-up\\":\\"(min-width:  992px)\\"}';
   display: none;
 }

--- a/tests/sass/json.scss
+++ b/tests/sass/json.scss
@@ -5,6 +5,11 @@ $breakpoints: (
     small-up:  (
         min-width: 400px
     ),
+    medium: (
+        media: screen,
+        min-width: 768px,
+        max-width: 991px,
+    ),
     medium-up: (
         media: screen,
         min-width: 768px,


### PR DESCRIPTION
The regex in question removes some quotes and whitespace, but it was slightly broken and removed too many spaces from multi-condition breakpoints. For example, `(min-width: 123px) and (max-width: 456px)` was incorrectly converted to  `(min-width: 123px)and(max-width: 456px)`. The missing spaces caused `window.matchMedia` to incorrectly report the media query as not matched.